### PR TITLE
Add support for fetching and showing qan messages

### DIFF
--- a/src/app/query-profile/query-profile.component.html
+++ b/src/app/query-profile/query-profile.component.html
@@ -10,6 +10,9 @@
   <a href="https://github.com/shatteredsilicon/ssm-doc/blob/1.x/docs/ssm-admin.md#adding-monitoring-services"
      target="blank">SSM documentation.</a>
 </div>
+<div *ngFor="let message of qanMessages" class="alert alert-warning w-75 mx-auto text-center wrap has-qan-message" role="alert">
+  {{ message.Content }}
+</div>
 <div *ngIf="dbServer !== null && dbServer !== undefined" class="content-container">
   <div *ngIf="!noQueryError" class="table-wrapper">
     <section class="table-header">

--- a/src/app/query-profile/query-profile.component.spec.ts
+++ b/src/app/query-profile/query-profile.component.spec.ts
@@ -98,6 +98,18 @@ fdescribe('QueryProfileComponent', () => {
     expect(contentContainer).toBeFalsy();
   });
 
+  it('should create alert message when there are qan messages', () => {
+    component.qanMessages = [{
+      Content: 'Throttling encountered while harvesting slow query log. Current long_query_time = 0.05, consider increasing to 0.10'
+    }];
+    component.dbServer = null;
+    fixture.detectChanges();
+    const qanMessage = fixture.nativeElement.querySelector('.has-qan-message');
+    const contentContainer = fixture.nativeElement.querySelector('.content-container');
+    expect(qanMessage).toBeTruthy();
+    expect(contentContainer).toBeFalsy();
+  });
+
   it('should create error message when no query data for mongodb', () => {
     component.totalAmountOfQueries = 0;
     component.dbServer.Subsystem = 'mongo';

--- a/src/app/query-profile/query-profile.service.ts
+++ b/src/app/query-profile/query-profile.service.ts
@@ -1,6 +1,10 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
 
+export interface QanMessage {
+  Content: string;
+};
+
 @Injectable()
 export class QueryProfileService {
 
@@ -26,5 +30,21 @@ export class QueryProfileService {
     return await this.httpClient
       .get(url, {headers: this.headers, params: params})
       .toPromise();
+  }
+
+  public async getQanMessages(agentUUID, dbServerUUID: string): Promise<any> {
+      const url = `/qan-api/agents/${agentUUID}/cmd`;
+
+      const params = {
+        AgentUUID: agentUUID,
+        Service: 'qan',
+        Cmd: 'GetMessages',
+        Data: btoa(dbServerUUID)
+      };
+
+      return this.httpClient
+        .put(url, params)
+        .toPromise()
+        .then(response => JSON.parse(atob(response['Data'])) as QanMessage[]);
   }
 }


### PR DESCRIPTION
![screenshot-2023-05-31 223730](https://github.com/shatteredsilicon/qan-app/assets/61085039/8a54735f-0192-412b-a785-9372111df54f)

The rate limit alert message is showing as above image, and it will be dismissed under 2 conditions:

- When `long_query_time` is set to the value it advises (0.001 if previous value is smaller than 0.001, 2x if it's greater than 0.001), note that the alert won't dismissed immediately after `long_query_time` is set to the advice value, because qan-agent isn't checking the `long_query_time` all the time, it will check the value in next interval, and that's when the alert will be dismissed.

- When runtime container / qan-agent service get restarted, the rate limit state will be re-initialized, thus the alert will be dismissed until next time it meets the rate limit again.